### PR TITLE
fix: consolidate Spring configuration to use only application.yml

### DIFF
--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=api


### PR DESCRIPTION
## Summary
- Removed duplicate application.properties file that only contained spring.application.name=api
- Consolidated all Spring configuration into application.yml as per Spring Boot best practices
- Resolved naming conflict where application.properties had 'api' but application.yml had 'people-and-organizations-api'

## Changes
- Deleted 
- All configuration now centralized in 

## Test Plan
- [x] Verified application.yml contains all necessary configuration
- [x] Confirmed no other application.properties files exist in the project
- [ ] CI/CD pipeline will validate the changes

Closes #20

🤖 Generated with [Claude Code](https://claude.ai/code)