### PR TITLE
fix: remove non-existent DefaultPackage rule exclusion from PMD configuration

### DIFF
--- a/config/pmd/pmd-rules.xml
+++ b/config/pmd/pmd-rules.xml
@@ -19,7 +19,6 @@
         <exclude name="AtLeastOneConstructor"/>
         <exclude name="CallSuperInConstructor"/>
         <exclude name="CommentDefaultAccessModifier"/>
-        <exclude name="DefaultPackage"/>
         <exclude name="OnlyOneReturn"/>
         <exclude name="TooManyStaticImports"/>
         <exclude name="UseUnderscoresInNumericLiterals"/>


### PR DESCRIPTION
## Summary
- Removed the DefaultPackage rule exclusion from PMD configuration
- This rule no longer exists in PMD 7.x, causing configuration warnings

## Problem
PMD 7.6.0 was reporting:
```
Warning at /Users/JimBarrows/projects.nosync/PeopleAndOrganizationDomain/config/pmd/pmd-rules.xml:22:9
Exclude pattern 'DefaultPackage' did not match any rule in ruleset 'category/java/codestyle.xml'
```

## Solution
Removed the non-existent DefaultPackage exclusion from the codestyle ruleset configuration.

## Changes
- Deleted line 22 (`<exclude name="DefaultPackage"/>`) from config/pmd/pmd-rules.xml

## Test Plan
- [x] Verified DefaultPackage exclusion was removed from PMD configuration
- [ ] CI/CD pipeline will validate PMD runs without configuration warnings
- [ ] Pre-push hooks will execute PMD checks successfully

Closes #23

🤖 Generated with [Claude Code](https://claude.ai/code)