### PR TITLE
fix: remove non-existent ExcessiveMethodLength rule from PMD configuration

### DIFF
--- a/config/pmd/pmd-rules.xml
+++ b/config/pmd/pmd-rules.xml
@@ -86,12 +86,6 @@
         </properties>
     </rule>
 
-    <rule ref="category/java/design.xml/ExcessiveMethodLength">
-        <properties>
-            <property name="minimum" value="50"/>
-        </properties>
-    </rule>
-
     <rule ref="category/java/design.xml/ExcessiveClassLength">
         <properties>
             <property name="minimum" value="500"/>


### PR DESCRIPTION
## Summary
- Removed the ExcessiveMethodLength rule reference that doesn't exist in PMD 7.x
- This rule has been reorganized or renamed in newer PMD versions

## Problem
PMD 7.6.0 was reporting:
```
Error at /Users/JimBarrows/projects.nosync/PeopleAndOrganizationDomain/config/pmd/pmd-rules.xml:90:5
Unable to find referenced rule ExcessiveMethodLength; perhaps the rule name is misspelled?
```

## Solution
Removed the non-existent ExcessiveMethodLength rule configuration from lines 89-93 in the PMD rules file.

## Changes
- Deleted the ExcessiveMethodLength rule block from config/pmd/pmd-rules.xml

## Notes
- Method length checking can be re-implemented using alternative PMD 7.x rules like NcssCount if needed
- Other "Excessive" rules (ExcessiveClassLength, ExcessiveParameterList) may also need attention in future updates

## Test Plan
- [x] Verified ExcessiveMethodLength rule was removed from PMD configuration
- [ ] CI/CD pipeline will validate PMD runs without "rule not found" errors
- [ ] Pre-push hooks will execute PMD checks successfully

Closes #24

🤖 Generated with [Claude Code](https://claude.ai/code)