### PR TITLE
fix: remove non-existent ExcessiveClassLength rule from PMD configuration

### DIFF
--- a/config/pmd/pmd-rules.xml
+++ b/config/pmd/pmd-rules.xml
@@ -86,12 +86,6 @@
         </properties>
     </rule>
 
-    <rule ref="category/java/design.xml/ExcessiveClassLength">
-        <properties>
-            <property name="minimum" value="500"/>
-        </properties>
-    </rule>
-
     <rule ref="category/java/design.xml/ExcessiveParameterList">
         <properties>
             <property name="minimum" value="6"/>


### PR DESCRIPTION
## Summary
- Removed the ExcessiveClassLength rule reference that doesn't exist in PMD 7.x
- This rule has been reorganized or renamed in newer PMD versions

## Problem
PMD 7.6.0 was reporting:
```
Error at /Users/JimBarrows/projects.nosync/PeopleAndOrganizationDomain/config/pmd/pmd-rules.xml:96:5
Unable to find referenced rule ExcessiveClassLength; perhaps the rule name is misspelled?
```

## Solution
Removed the non-existent ExcessiveClassLength rule configuration from lines 89-93 in the PMD rules file.

## Changes
- Deleted the ExcessiveClassLength rule block from config/pmd/pmd-rules.xml

## Notes
- Class size checking can be re-implemented using alternative PMD 7.x rules if needed
- The ExcessiveParameterList rule (still present in the config) may also need attention in future updates

## Test Plan
- [x] Verified ExcessiveClassLength rule was removed from PMD configuration
- [ ] CI/CD pipeline will validate PMD runs without "rule not found" errors
- [ ] Pre-push hooks will execute PMD checks successfully

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)