### PR TITLE
fix: remove non-existent PMD rule exclusions

### DIFF
--- a/config/pmd/pmd-rules.xml
+++ b/config/pmd/pmd-rules.xml
@@ -42,8 +42,6 @@
 
     <!-- Error Prone -->
     <rule ref="category/java/errorprone.xml">
-        <exclude name="BeanMembersShouldSerialize"/>
-        <exclude name="DataflowAnomalyAnalysis"/>
         <exclude name="NullAssignment"/>
         <exclude name="UseProperClassLoader"/>
         <exclude name="AvoidFieldNameMatchingMethodName"/>


### PR DESCRIPTION
## Summary
- Removed BeanMembersShouldSerialize exclusion from PMD errorprone rules
- Removed DataflowAnomalyAnalysis exclusion from PMD errorprone rules  
- Fixed PMD 7.6.0 configuration warnings about non-matching exclude patterns

## Changes Made
**Before (lines 45-46):**
```xml
<exclude name="BeanMembersShouldSerialize"/>
<exclude name="DataflowAnomalyAnalysis"/>
```

**After:**
These exclusions have been removed as the rules no longer exist in PMD 7.x

## Root Cause
In PMD 7.x, these rules have been removed or renamed:
- `BeanMembersShouldSerialize` rule no longer exists
- `DataflowAnomalyAnalysis` rule no longer exists

## Test Plan
- [x] PMD main analysis runs without configuration warnings
- [x] PMD test analysis runs without configuration warnings
- [x] Pre-commit hooks pass with PMD checks
- [ ] CI/CD Code Quality Analysis job passes PMD phase

## Impact
- Eliminates PMD configuration warnings
- Ensures PMD 7.6.0 compatibility
- Cleans up obsolete rule exclusions

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/code)