### PR TITLE
fix: resolve duplicate PMD rule references

### DIFF
--- a/config/pmd/pmd-rules.xml
+++ b/config/pmd/pmd-rules.xml
@@ -12,6 +12,8 @@
         <exclude name="JUnitAssertionsShouldIncludeMessage"/>
         <exclude name="JUnitTestContainsTooManyAsserts"/>
         <exclude name="UseVarargs"/>
+        <exclude name="MethodReturnsInternalArray"/>
+        <exclude name="ArrayIsStoredDirectly"/>
     </rule>
 
     <!-- Code Style -->
@@ -32,6 +34,10 @@
         <exclude name="LawOfDemeter"/>
         <exclude name="LoosePackageCoupling"/>
         <exclude name="UseUtilityClass"/>
+        <exclude name="TooManyMethods"/>
+        <exclude name="TooManyFields"/>
+        <exclude name="CyclomaticComplexity"/>
+        <exclude name="ExcessiveParameterList"/>
     </rule>
 
     <!-- Documentation -->
@@ -60,7 +66,7 @@
     <!-- Security -->
     <rule ref="category/java/security.xml"/>
 
-    <!-- Custom rules -->
+    <!-- Custom rules with default configuration -->
     <rule ref="category/java/bestpractices.xml/MethodReturnsInternalArray"/>
     <rule ref="category/java/bestpractices.xml/ArrayIsStoredDirectly"/>
 


### PR DESCRIPTION
## Summary
- Fixed duplicate PMD rule references that were causing configuration warnings
- Excluded rules from category imports when they have custom configurations
- Ensured each rule is configured exactly once

## Changes Made
**Before:** Rules were included in category imports AND configured individually, causing duplication warnings

**After:** 
- Excluded duplicated rules from category imports:
  - `MethodReturnsInternalArray` and `ArrayIsStoredDirectly` from bestpractices category
  - `TooManyMethods`, `TooManyFields`, `CyclomaticComplexity`, `ExcessiveParameterList` from design category
- Kept individual rule configurations with custom properties

## Root Cause
PMD 7.6.0 detects when the same rule is referenced multiple times in a ruleset:
1. Once via category import (e.g., `category/java/bestpractices.xml`)
2. Again as individual rule with custom configuration

## Test Plan
- [x] PMD main analysis runs without duplicate rule warnings
- [x] PMD test analysis runs without duplicate rule warnings
- [x] Custom rule properties are properly applied
- [x] Pre-commit hooks pass with PMD checks
- [ ] CI/CD Code Quality Analysis job passes PMD phase

## Impact
- Eliminates PMD configuration warnings about duplicate rules
- Clarifies which rule configuration is actually being used
- Ensures PMD 7.6.0 compatibility
- Maintains all custom rule properties

**Fixed Warnings:**
- MethodReturnsInternalArray is referenced multiple times ✅
- ArrayIsStoredDirectly is referenced multiple times ✅ 
- CyclomaticComplexity is referenced multiple times ✅

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)