### PR TITLE
fix: remove hardcoded Java home path from gradle.properties

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,40 @@ PeopleAndOrganizationDomain/
 
 ### Environment Setup
 
+#### Java Configuration
+
+This project requires Java 21. There are several ways to configure it:
+
+**Option 1: Set JAVA_HOME environment variable (recommended)**
 ```bash
-# Ensure Java 21 is available (project uses gradle.properties to configure)
-java -version  # Should show Java 21 or compatible
+# macOS/Linux
+export JAVA_HOME=/path/to/java21
+
+# Windows
+set JAVA_HOME=C:\path\to\java21
+```
+
+**Option 2: Use gradle.properties (for local development only)**
+```bash
+# Copy the template
+cp gradle.properties.template gradle.properties
+
+# Edit gradle.properties and uncomment/set:
+# org.gradle.java.home=/path/to/java21
+```
+
+**Common Java 21 locations:**
+- macOS (SDKMAN): `~/.sdkman/candidates/java/21.x.x-vendor`
+- macOS (Homebrew): `/opt/homebrew/opt/openjdk@21`
+- macOS (Oracle/OpenJDK): `/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home`
+- Linux: `/usr/lib/jvm/java-21-openjdk`
+- Windows: `C:\Program Files\Java\jdk-21`
+
+**Note:** The gradle.properties file is tracked by git and should NOT contain machine-specific paths. Use environment variables or local overrides instead.
+
+```bash
+# Verify Java version
+java -version  # Should show Java 21
 
 # Clone and setup
 git clone <repository>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 # Java home should be set by the environment (CI or local)
-org.gradle.java.home=/Users/JimBarrows/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home
+# org.gradle.java.home=/path/to/java/home
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m

--- a/gradle.properties.template
+++ b/gradle.properties.template
@@ -1,0 +1,30 @@
+# Template for gradle.properties
+# Copy this file to gradle.properties and customize for your local environment
+
+# Java Configuration
+# -----------------
+# Option 1: Set JAVA_HOME environment variable (recommended)
+# export JAVA_HOME=/path/to/java21
+#
+# Option 2: Configure in gradle.properties (local only)
+# org.gradle.java.home=/path/to/java21/home
+#
+# Common Java 21 locations:
+# macOS (SDKMAN): ~/.sdkman/candidates/java/21.x.x-vendor
+# macOS (Homebrew): /opt/homebrew/opt/openjdk@21
+# macOS (Oracle/OpenJDK): /Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home
+# Linux: /usr/lib/jvm/java-21-openjdk
+# Windows: C:\\Program Files\\Java\\jdk-21
+
+# JVM Arguments
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
+
+# Build Cache (optional, improves build performance)
+# org.gradle.caching=true
+
+# Parallel execution (optional, improves build performance)
+# org.gradle.parallel=true
+
+# Daemon settings (optional)
+# org.gradle.daemon=true
+# org.gradle.daemon.idletimeout=3600000


### PR DESCRIPTION
## Summary
- Removed machine-specific Java home path from gradle.properties
- Created gradle.properties.template with configuration examples  
- Updated documentation with Java configuration instructions

## Problem
The gradle.properties file contained a hardcoded Java home path that was specific to one developer's machine, causing build failures on other systems:
```
org.gradle.java.home=/Users/JimBarrows/Library/Java/JavaVirtualMachines/openjdk-21.0.2/Contents/Home
```

## Solution
1. **Removed hardcoded path** - Changed to commented example in gradle.properties
2. **Created template file** - Added gradle.properties.template with:
   - Configuration examples for different platforms
   - Common Java 21 installation locations
   - Optional performance settings
3. **Updated documentation** - Enhanced CLAUDE.md with:
   - Multiple configuration options (environment variable vs local config)
   - Platform-specific Java paths
   - Clear instructions for developers

## Configuration Options
Developers can now configure Java 21 using:
- **Option 1**: Set JAVA_HOME environment variable (recommended)
- **Option 2**: Create local gradle.properties from template

## Test Plan
- [x] Build works with JAVA_HOME environment variable
- [x] Build works without any Java home configuration (uses system default)
- [x] gradle.properties.template provides clear examples
- [x] Documentation is comprehensive and helpful

## Why This Wasn't Caught by Pre-commit
The pre-commit hooks check for Java availability at runtime but don't validate configuration files for hardcoded paths. The path worked on the machine where it was committed, so pre-commit passed.

Closes #40

🤖 Generated with [Claude Code](https://claude.ai/code)